### PR TITLE
Helm chart: ingress: extraPaths parameter

### DIFF
--- a/charts/rota-slackbot/templates/ingress.yaml
+++ b/charts/rota-slackbot/templates/ingress.yaml
@@ -58,4 +58,7 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
+{{- if .Values.ingress.extraPaths }}
+{{ toYaml .Values.ingress.extraPaths | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/rota-slackbot/templates/ingress.yaml
+++ b/charts/rota-slackbot/templates/ingress.yaml
@@ -57,8 +57,8 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
+          {{- if $.Values.ingress.extraPaths }}
+          {{- toYaml $.Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
     {{- end }}
-{{- if .Values.ingress.extraPaths }}
-{{ toYaml .Values.ingress.extraPaths | indent 10 }}
-{{- end }}
 {{- end }}

--- a/charts/rota-slackbot/values.yaml
+++ b/charts/rota-slackbot/values.yaml
@@ -64,6 +64,14 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # extraPaths:
+  #   - path: /
+  #     pathType: "Prefix"
+  #     backend:
+  #       service:
+  #         name: ssl-redirect
+  #         port:
+  #           name: use-annotation
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -85,3 +93,9 @@ affinity: {}
 
 autoscaling:
   enabled: false
+
+# Values used for local testing of the Helm template output.
+# slackbot:
+#   token: test-value
+#   signingSecret: test-value
+#   team: test-value


### PR DESCRIPTION
This PR implements the `extraPaths` parameter for the optional Ingress Kubernetes resource for this project's Helm chart on changes implemented in Vivino/kubernetes-platform#405.

By default, this shall result in no changes when the Helm chart is deployed.

Related to Vivino/kubernetes-platform#411.

Tested locally with test values, the Helm templates for the Ingress resource were generated correctly.

Note that the extra paths are added to each host defined.