### PR TITLE
Helm chart: bump version #45827

### DIFF
--- a/charts/rota-slackbot/Chart.yaml
+++ b/charts/rota-slackbot/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to run rota-slackbot in kubernetes
 
 type: application
 
-version: 1.0.5
+version: 1.0.6
 
 appVersion: "v1.0.2"
 


### PR DESCRIPTION
This PR bumps the Helm chart version to `1.0.6`, to fix the deployment of #2.