### PR TITLE
Helm chart: ingress: remove extraPaths

### DIFF
--- a/charts/rota-slackbot/Chart.yaml
+++ b/charts/rota-slackbot/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to run rota-slackbot in kubernetes
 
 type: application
 
-version: 1.0.6
+version: 1.0.7
 
 appVersion: "v1.0.2"
 

--- a/charts/rota-slackbot/templates/ingress.yaml
+++ b/charts/rota-slackbot/templates/ingress.yaml
@@ -57,8 +57,5 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
-          {{- if $.Values.ingress.extraPaths }}
-          {{- toYaml $.Values.ingress.extraPaths | nindent 10 }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/rota-slackbot/values.yaml
+++ b/charts/rota-slackbot/values.yaml
@@ -64,14 +64,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  # extraPaths:
-  #   - path: /
-  #     pathType: "Prefix"
-  #     backend:
-  #       service:
-  #         name: ssl-redirect
-  #         port:
-  #           name: use-annotation
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR removes the `extraPaths` parameter from the Helm chart's Ingress configuration and uses annotations to enable SSL redirects.

Values are defined as part of Vivino/kubernetes-platform#414.

